### PR TITLE
feat(deleting dbs): succeed even if db does not exist (DHIS2-9492)

### DIFF
--- a/src/indexedDb/clearDatabasesByKey.js
+++ b/src/indexedDb/clearDatabasesByKey.js
@@ -1,3 +1,6 @@
 import { deleteDb } from './deleteDb'
 
-export const clearDatabasesByKey = keys => Promise.all(keys.map(deleteDb))
+export const clearDatabasesByKey = keys => {
+    const allDeleteProcesses = keys.map(key => deleteDb(key, true))
+    return Promise.all(allDeleteProcesses)
+}

--- a/src/indexedDb/deleteDb.js
+++ b/src/indexedDb/deleteDb.js
@@ -1,6 +1,6 @@
 import { dbExists } from './dbExists'
 
-export const deleteDb = name =>
+export const deleteDb = (name, succeedWhenNonExistant = false) =>
     dbExists(name).then(exists => {
         if (exists) {
             return new Promise((resolve, reject) => {
@@ -11,5 +11,5 @@ export const deleteDb = name =>
             })
         }
 
-        return Promise.reject()
+        return succeedWhenNonExistant ? Promise.resolve() : Promise.reject()
     })


### PR DESCRIPTION
Fixes DHIS2-9492

Attempting to delete a non existing db will not cause the app to hang anymore.
Previously attempting to delete non existing dbs caused the app to throw an error which prevented the list from being reloaded.